### PR TITLE
Fix filtering by biomes found within radius

### DIFF
--- a/src/main/java/com/chaosthedude/naturescompass/NaturesCompass.java
+++ b/src/main/java/com/chaosthedude/naturescompass/NaturesCompass.java
@@ -10,7 +10,11 @@ import org.apache.logging.log4j.Logger;
 import com.chaosthedude.naturescompass.config.ConfigHandler;
 import com.chaosthedude.naturescompass.gui.GuiHandler;
 import com.chaosthedude.naturescompass.items.ItemNaturesCompass;
-import com.chaosthedude.naturescompass.network.*;
+import com.chaosthedude.naturescompass.network.PacketAvailableBiomesSet;
+import com.chaosthedude.naturescompass.network.PacketCompassSearch;
+import com.chaosthedude.naturescompass.network.PacketRequestSync;
+import com.chaosthedude.naturescompass.network.PacketSync;
+import com.chaosthedude.naturescompass.network.PacketTeleport;
 import com.chaosthedude.naturescompass.proxy.CommonProxy;
 
 import cpw.mods.fml.common.Mod;

--- a/src/main/java/com/chaosthedude/naturescompass/NaturesCompass.java
+++ b/src/main/java/com/chaosthedude/naturescompass/NaturesCompass.java
@@ -10,10 +10,7 @@ import org.apache.logging.log4j.Logger;
 import com.chaosthedude.naturescompass.config.ConfigHandler;
 import com.chaosthedude.naturescompass.gui.GuiHandler;
 import com.chaosthedude.naturescompass.items.ItemNaturesCompass;
-import com.chaosthedude.naturescompass.network.PacketCompassSearch;
-import com.chaosthedude.naturescompass.network.PacketRequestSync;
-import com.chaosthedude.naturescompass.network.PacketSync;
-import com.chaosthedude.naturescompass.network.PacketTeleport;
+import com.chaosthedude.naturescompass.network.*;
 import com.chaosthedude.naturescompass.proxy.CommonProxy;
 
 import cpw.mods.fml.common.Mod;
@@ -62,9 +59,10 @@ public class NaturesCompass {
 
         network = NetworkRegistry.INSTANCE.newSimpleChannel(MODID);
         network.registerMessage(PacketCompassSearch.Handler.class, PacketCompassSearch.class, 0, Side.SERVER);
-        network.registerMessage(PacketTeleport.Handler.class, PacketTeleport.class, 1, Side.SERVER);
-        network.registerMessage(PacketRequestSync.Handler.class, PacketRequestSync.class, 2, Side.SERVER);
-        network.registerMessage(PacketSync.Handler.class, PacketSync.class, 3, Side.CLIENT);
+        network.registerMessage(PacketAvailableBiomesSet.Handler.class, PacketAvailableBiomesSet.class, 1, Side.CLIENT);
+        network.registerMessage(PacketTeleport.Handler.class, PacketTeleport.class, 2, Side.SERVER);
+        network.registerMessage(PacketRequestSync.Handler.class, PacketRequestSync.class, 3, Side.SERVER);
+        network.registerMessage(PacketSync.Handler.class, PacketSync.class, 4, Side.CLIENT);
 
         proxy.registerEvents();
         proxy.registerModels();

--- a/src/main/java/com/chaosthedude/naturescompass/gui/GuiBiomeInfo.java
+++ b/src/main/java/com/chaosthedude/naturescompass/gui/GuiBiomeInfo.java
@@ -93,7 +93,7 @@ public class GuiBiomeInfo extends GuiScreen {
     protected void actionPerformed(GuiButton button) {
         if (button.enabled) {
             if (button == searchButton) {
-                parentScreen.searchForBiome(biome);
+                parentScreen.searchForBiome(biome.biomeID);
             } else if (button == backButton) {
                 mc.displayGuiScreen(parentScreen);
             }

--- a/src/main/java/com/chaosthedude/naturescompass/gui/GuiListBiomesEntry.java
+++ b/src/main/java/com/chaosthedude/naturescompass/gui/GuiListBiomesEntry.java
@@ -73,7 +73,7 @@ public class GuiListBiomesEntry implements GuiListExtended.IGuiListEntry {
     public void selectBiome() {
         mc.getSoundHandler()
                 .playSound(PositionedSoundRecord.func_147674_a(new ResourceLocation("gui.button.press"), 1.0F));
-        guiNaturesCompass.searchForBiome(biome);
+        guiNaturesCompass.searchForBiome(biome.biomeID);
     }
 
     public void viewInfo() {

--- a/src/main/java/com/chaosthedude/naturescompass/gui/GuiNaturesCompass.java
+++ b/src/main/java/com/chaosthedude/naturescompass/gui/GuiNaturesCompass.java
@@ -2,10 +2,12 @@ package com.chaosthedude.naturescompass.gui;
 
 import java.util.*;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
@@ -23,6 +25,7 @@ import com.chaosthedude.naturescompass.util.BiomeUtils;
 import com.chaosthedude.naturescompass.util.EnumCompassState;
 import com.chaosthedude.naturescompass.util.PlayerUtils;
 
+import cpw.mods.fml.client.config.GuiCheckBox;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
@@ -34,12 +37,15 @@ public class GuiNaturesCompass extends GuiScreen {
     private ItemStack stack;
     private ItemNaturesCompass natureCompass;
     private List<BiomeGenBase> allowedBiomes;
+    public Set<BiomeGenBase> availableBiomes;
+    private List<BiomeGenBase> baseBiomeList;
     private List<BiomeGenBase> biomesMatchingSearch;
     private GuiButton searchButton;
     private GuiButton teleportButton;
     private GuiButton infoButton;
     private GuiButton cancelButton;
     private GuiButton sortByButton;
+    private GuiCheckBox availableCheckBox;
     private GuiTransparentTextField searchTextField;
     private GuiListBiomes selectionList;
     private ISortingCategory sortingCategory;
@@ -51,11 +57,15 @@ public class GuiNaturesCompass extends GuiScreen {
         this.stack = stack;
         this.natureCompass = natureCompass;
         this.allowedBiomes = allowedBiomes;
+        this.availableBiomes = new HashSet<>();
+        this.baseBiomeList = allowedBiomes;
 
         sortingCategory = new CategoryName();
         biomesMatchingSearch = new ArrayList<BiomeGenBase>(allowedBiomes);
 
-        updateBiomesEntry();
+        if (!Minecraft.getMinecraft().isIntegratedServerRunning()) {
+            NaturesCompass.network.sendToServer(new PacketCompassSearch(-1, (int) player.posX, (int) player.posZ));
+        }
     }
 
     @Override
@@ -92,6 +102,32 @@ public class GuiNaturesCompass extends GuiScreen {
                 selectionList.refreshList();
             } else if (button == cancelButton) {
                 mc.displayGuiScreen(null);
+            } else if (button == availableCheckBox) {
+                if (Minecraft.getMinecraft().isIntegratedServerRunning() && availableBiomes.isEmpty()) {
+                    // Extremely bad workaround for workers not ticking on integrated server when GUIs are closed
+                    // This WILL lag the compass interface in SP, but only when this box is ticked so it's not that bad
+                    World serverWorld = Minecraft.getMinecraft().getIntegratedServer()
+                            .worldServerForDimension(player.dimension);
+                    EntityPlayerMP playerMP = (EntityPlayerMP) serverWorld.getEntityByID(player.getEntityId());
+
+                    BiomeSearchWorker worker = new BiomeSearchWorker(
+                            serverWorld,
+                            playerMP,
+                            stack,
+                            -1,
+                            (int) player.posX,
+                            (int) player.posZ);
+                    while (worker.hasWork()) worker.doWork();
+                    availableBiomes = worker.availableBiomes;
+                }
+
+                if (((GuiCheckBox) button).isChecked()) {
+                    baseBiomeList = new ArrayList<>(availableBiomes);
+                } else {
+                    baseBiomeList = allowedBiomes;
+                }
+                processSearchTerm();
+                selectionList.refreshList();
             }
         }
     }
@@ -131,17 +167,9 @@ public class GuiNaturesCompass extends GuiScreen {
         infoButton.enabled = enable;
     }
 
-    public void searchForBiome(BiomeGenBase biome) {
-        NaturesCompass.network
-                .sendToServer(new PacketCompassSearch(biome.biomeID, (int) player.posX, (int) player.posZ));
+    public void searchForBiome(int biomeID) {
+        NaturesCompass.network.sendToServer(new PacketCompassSearch(biomeID, (int) player.posX, (int) player.posZ));
         mc.displayGuiScreen(null);
-    }
-
-    public void updateBiomesEntry() {
-        if (BiomeSearchWorker.completedSearch && (BiomeSearchWorker.oldDimensionId == world.provider.dimensionId)
-                && (BiomeSearchWorker.availableBiomes != null)) {
-            allowedBiomes = biomesMatchingSearch = new ArrayList<BiomeGenBase>(BiomeSearchWorker.availableBiomes);
-        }
     }
 
     public void teleport() {
@@ -158,20 +186,20 @@ public class GuiNaturesCompass extends GuiScreen {
         Set<BiomeGenBase> biomeMatching = new HashSet<BiomeGenBase>();
 
         if (category.equals(I18n.format("string.naturescompass.name").toLowerCase())) {
-            for (BiomeGenBase biome : allowedBiomes) {
+            for (BiomeGenBase biome : baseBiomeList) {
                 if (BiomeUtils.getBiomeName(biome).toLowerCase().contains(value)) {
                     biomeMatching.add(biome);
                 }
             }
         } else if (category.equals(I18n.format("string.naturescompass.climate").toLowerCase())) {
-            for (BiomeGenBase biome : allowedBiomes) {
+            for (BiomeGenBase biome : baseBiomeList) {
                 if (BiomeUtils.getBiomeClimate(biome).toLowerCase().contains(value)) {
                     biomeMatching.add(biome);
                 }
             }
         } else if (category.equals(I18n.format("string.naturescompass.baseHeight").toLowerCase())
                 || category.equals("bh")) {
-                    for (BiomeGenBase biome : allowedBiomes) {
+                    for (BiomeGenBase biome : baseBiomeList) {
                         if (String.valueOf(biome.rootHeight).contains(value)) {
                             biomeMatching.add(biome);
                         }
@@ -179,7 +207,7 @@ public class GuiNaturesCompass extends GuiScreen {
                 } else
             if (category.equals(I18n.format("string.naturescompass.heightVariation").toLowerCase())
                     || category.equals("hv")) {
-                        for (BiomeGenBase biome : allowedBiomes) {
+                        for (BiomeGenBase biome : baseBiomeList) {
                             if (String.valueOf(biome.heightVariation).contains(value)) {
                                 biomeMatching.add(biome);
                             }
@@ -187,7 +215,7 @@ public class GuiNaturesCompass extends GuiScreen {
                     } else
                 if (category.equals(I18n.format("string.naturescompass.rainfall").toLowerCase())
                         || category.equals("rain")) {
-                            for (BiomeGenBase biome : allowedBiomes) {
+                            for (BiomeGenBase biome : baseBiomeList) {
                                 if (String.valueOf(biome.rainfall).contains(value)) {
                                     biomeMatching.add(biome);
                                 }
@@ -195,21 +223,21 @@ public class GuiNaturesCompass extends GuiScreen {
                         } else
                     if (category.equals(I18n.format("string.naturescompass.temperature").toLowerCase())
                             || category.equals("temp")) {
-                                for (BiomeGenBase biome : allowedBiomes) {
+                                for (BiomeGenBase biome : baseBiomeList) {
                                     if (String.valueOf(biome.temperature).contains(value)) {
                                         biomeMatching.add(biome);
                                     }
                                 }
                             } else
                         if (category.equals(I18n.format("string.naturescompass.humidity").toLowerCase())) {
-                            for (BiomeGenBase biome : allowedBiomes) {
+                            for (BiomeGenBase biome : baseBiomeList) {
                                 if (BiomeUtils.getBiomeHumidity(biome).toLowerCase().contains(value)) {
                                     biomeMatching.add(biome);
                                 }
                             }
                         } else if (category.equals(I18n.format("string.naturescompass.tags").toLowerCase())
                                 || category.equals("tag")) {
-                                    for (BiomeGenBase biome : allowedBiomes) {
+                                    for (BiomeGenBase biome : baseBiomeList) {
                                         if (BiomeUtils.getListBiomeTags(biome).contains(value)) {
                                             biomeMatching.add(biome);
                                         }
@@ -221,7 +249,7 @@ public class GuiNaturesCompass extends GuiScreen {
     public void processSearchTerm() {
         String text = searchTextField.getText().toLowerCase();
         String[] arrayText = text.trim().split("\\s*,\\s*");
-        Set<BiomeGenBase> biomeMatchingTemp2 = new HashSet<>(allowedBiomes);
+        Set<BiomeGenBase> biomeMatchingTemp2 = new HashSet<>(baseBiomeList);
 
         for (String part : arrayText) {
             String[] arrayPart = part.trim().split("\\s*:\\s*", 2);
@@ -271,6 +299,8 @@ public class GuiNaturesCompass extends GuiScreen {
                 new GuiTransparentButton(3, 10, 40, 110, 20, I18n.format("string.naturescompass.search")));
         teleportButton = addButton(
                 new GuiTransparentButton(4, 10, height - 55, 110, 20, I18n.format("string.naturescompass.teleport")));
+        availableCheckBox = addButton(
+                new GuiCheckBox(5, 10, 115, I18n.format("string.naturescompass.foundOnly"), false));
 
         searchButton.enabled = false;
         infoButton.enabled = false;

--- a/src/main/java/com/chaosthedude/naturescompass/gui/GuiNaturesCompass.java
+++ b/src/main/java/com/chaosthedude/naturescompass/gui/GuiNaturesCompass.java
@@ -121,13 +121,7 @@ public class GuiNaturesCompass extends GuiScreen {
                     availableBiomes = worker.availableBiomes;
                 }
 
-                if (((GuiCheckBox) button).isChecked()) {
-                    baseBiomeList = new ArrayList<>(availableBiomes);
-                } else {
-                    baseBiomeList = allowedBiomes;
-                }
-                processSearchTerm();
-                selectionList.refreshList();
+                updateListState();
             }
         }
     }
@@ -275,6 +269,16 @@ public class GuiNaturesCompass extends GuiScreen {
         Collections.sort(biomes, sortingCategory);
 
         return biomes;
+    }
+
+    public void updateListState() {
+        if (availableCheckBox.isChecked()) {
+            baseBiomeList = new ArrayList<>(availableBiomes);
+        } else {
+            baseBiomeList = allowedBiomes;
+        }
+        processSearchTerm();
+        selectionList.refreshList();
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/com/chaosthedude/naturescompass/items/ItemNaturesCompass.java
+++ b/src/main/java/com/chaosthedude/naturescompass/items/ItemNaturesCompass.java
@@ -7,13 +7,13 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityItemFrame;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
-import net.minecraft.world.biome.BiomeGenBase;
 
 import com.chaosthedude.naturescompass.NaturesCompass;
 import com.chaosthedude.naturescompass.network.PacketRequestSync;
@@ -56,7 +56,6 @@ public class ItemNaturesCompass extends Item {
             player.openGui(NaturesCompass.instance, 0, world, 0, 0, 0);
         } else {
             setState(stack, EnumCompassState.INACTIVE, player);
-            BiomeSearchWorker.completedSearch = false;
         }
 
         return stack;
@@ -94,10 +93,13 @@ public class ItemNaturesCompass extends Item {
         return true;
     }
 
-    public void searchForBiome(World world, EntityPlayer player, int biomeID, int x, int z, ItemStack stack) {
-        setState(stack, EnumCompassState.SEARCHING, player);
-        setBiomeID(stack, biomeID, player);
-        BiomeSearchWorker worker = new BiomeSearchWorker(world, player, stack, BiomeGenBase.getBiome(biomeID), x, z);
+    public void searchForBiome(World world, EntityPlayerMP player, int biomeID, int x, int z, ItemStack stack) {
+        if (biomeID != -1) {
+            setState(stack, EnumCompassState.SEARCHING, player);
+            setBiomeID(stack, biomeID, player);
+        }
+
+        BiomeSearchWorker worker = new BiomeSearchWorker(world, player, stack, biomeID, x, z);
         worker.start();
     }
 

--- a/src/main/java/com/chaosthedude/naturescompass/network/PacketAvailableBiomesSet.java
+++ b/src/main/java/com/chaosthedude/naturescompass/network/PacketAvailableBiomesSet.java
@@ -47,7 +47,9 @@ public class PacketAvailableBiomesSet implements IMessage {
         @Override
         public IMessage onMessage(PacketAvailableBiomesSet message, MessageContext ctx) {
             if (Minecraft.getMinecraft().currentScreen instanceof GuiNaturesCompass) {
-                ((GuiNaturesCompass) Minecraft.getMinecraft().currentScreen).availableBiomes = message.biomes;
+                GuiNaturesCompass gui = ((GuiNaturesCompass) Minecraft.getMinecraft().currentScreen);
+                gui.availableBiomes = message.biomes;
+                gui.updateListState();
             }
             return null;
         }

--- a/src/main/java/com/chaosthedude/naturescompass/network/PacketAvailableBiomesSet.java
+++ b/src/main/java/com/chaosthedude/naturescompass/network/PacketAvailableBiomesSet.java
@@ -1,0 +1,55 @@
+package com.chaosthedude.naturescompass.network;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.biome.BiomeGenBase;
+
+import com.chaosthedude.naturescompass.gui.GuiNaturesCompass;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import io.netty.buffer.ByteBuf;
+
+public class PacketAvailableBiomesSet implements IMessage {
+
+    private Set<BiomeGenBase> biomes;
+
+    public PacketAvailableBiomesSet() {}
+
+    public PacketAvailableBiomesSet(Set<BiomeGenBase> biomes) {
+        this.biomes = biomes;
+    }
+
+    @Override
+    public void fromBytes(ByteBuf buf) {
+        biomes = new HashSet<>();
+
+        int size = buf.readInt();
+        for (int i = 0; i < size; ++i) {
+            biomes.add(BiomeGenBase.getBiome(buf.readInt()));
+        }
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf) {
+        buf.writeInt(biomes.size());
+
+        for (BiomeGenBase biome : biomes) {
+            buf.writeInt(biome.biomeID);
+        }
+    }
+
+    public static class Handler implements IMessageHandler<PacketAvailableBiomesSet, IMessage> {
+
+        @Override
+        public IMessage onMessage(PacketAvailableBiomesSet message, MessageContext ctx) {
+            if (Minecraft.getMinecraft().currentScreen instanceof GuiNaturesCompass) {
+                ((GuiNaturesCompass) Minecraft.getMinecraft().currentScreen).availableBiomes = message.biomes;
+            }
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/chaosthedude/naturescompass/network/PacketCompassSearch.java
+++ b/src/main/java/com/chaosthedude/naturescompass/network/PacketCompassSearch.java
@@ -51,6 +51,7 @@ public class PacketCompassSearch implements IMessage {
             if (stack != null && stack.getItem() == NaturesCompass.naturesCompass) {
                 final ItemNaturesCompass natureCompass = (ItemNaturesCompass) stack.getItem();
                 final World world = ctx.getServerHandler().playerEntity.worldObj;
+
                 natureCompass.searchForBiome(
                         world,
                         ctx.getServerHandler().playerEntity,

--- a/src/main/java/com/chaosthedude/naturescompass/network/PacketRequestSync.java
+++ b/src/main/java/com/chaosthedude/naturescompass/network/PacketRequestSync.java
@@ -1,6 +1,5 @@
 package com.chaosthedude.naturescompass.network;
 
-import com.chaosthedude.naturescompass.util.BiomeSearchWorker;
 import com.chaosthedude.naturescompass.util.PlayerUtils;
 
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
@@ -23,11 +22,7 @@ public class PacketRequestSync implements IMessage {
         @Override
         public IMessage onMessage(PacketRequestSync packet, MessageContext ctx) {
             final boolean canTeleport = PlayerUtils.canTeleport(ctx.getServerHandler().playerEntity);
-            return new PacketSync(
-                    canTeleport,
-                    BiomeSearchWorker.availableBiomes,
-                    BiomeSearchWorker.oldDimensionId,
-                    BiomeSearchWorker.completedSearch);
+            return new PacketSync(canTeleport);
         }
     }
 }

--- a/src/main/java/com/chaosthedude/naturescompass/network/PacketSync.java
+++ b/src/main/java/com/chaosthedude/naturescompass/network/PacketSync.java
@@ -1,12 +1,6 @@
 package com.chaosthedude.naturescompass.network;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import net.minecraft.world.biome.BiomeGenBase;
-
 import com.chaosthedude.naturescompass.NaturesCompass;
-import com.chaosthedude.naturescompass.util.BiomeSearchWorker;
 
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
@@ -16,41 +10,21 @@ import io.netty.buffer.ByteBuf;
 public class PacketSync implements IMessage {
 
     private boolean canTeleport;
-    private Set<BiomeGenBase> availableBiomes;
-    private int oldDimensionId;
-    private boolean completedSearch;
 
     public PacketSync() {}
 
-    public PacketSync(boolean canTeleport, Set<BiomeGenBase> availableBiomes, int oldDimensionId,
-            boolean completedSearch) {
+    public PacketSync(boolean canTeleport) {
         this.canTeleport = canTeleport;
-        this.availableBiomes = availableBiomes;
-        this.oldDimensionId = oldDimensionId;
-        this.completedSearch = completedSearch;
     }
 
     @Override
     public void fromBytes(ByteBuf buf) {
         canTeleport = buf.readBoolean();
-        availableBiomes = new HashSet<BiomeGenBase>();
-        int size = buf.readInt();
-        for (int i = 0; i < size; i++) {
-            availableBiomes.add(BiomeGenBase.getBiome(buf.readInt()));
-        }
-        oldDimensionId = buf.readInt();
-        completedSearch = buf.readBoolean();
     }
 
     @Override
     public void toBytes(ByteBuf buf) {
         buf.writeBoolean(canTeleport);
-        buf.writeInt(availableBiomes.size());
-        for (BiomeGenBase biome : availableBiomes) {
-            buf.writeInt(biome.biomeID);
-        }
-        buf.writeInt(oldDimensionId);
-        buf.writeBoolean(completedSearch);
     }
 
     public static class Handler implements IMessageHandler<PacketSync, IMessage> {
@@ -58,9 +32,6 @@ public class PacketSync implements IMessage {
         @Override
         public IMessage onMessage(PacketSync packet, MessageContext ctx) {
             NaturesCompass.canTeleport = packet.canTeleport;
-            BiomeSearchWorker.availableBiomes = packet.availableBiomes;
-            BiomeSearchWorker.oldDimensionId = packet.oldDimensionId;
-            BiomeSearchWorker.completedSearch = packet.completedSearch;
 
             return null;
         }

--- a/src/main/java/com/chaosthedude/naturescompass/util/BiomeSearchWorker.java
+++ b/src/main/java/com/chaosthedude/naturescompass/util/BiomeSearchWorker.java
@@ -118,8 +118,9 @@ public class BiomeSearchWorker implements WorldWorkerManager.IWorker {
                 NaturesCompass.logger.info("Search failed: " + getRadius() + " radius, " + samples + " samples");
                 ((ItemNaturesCompass) stack.getItem()).setNotFound(stack, player, roundRadius(getRadius(), 500));
             }
-        } else {
-            NaturesCompass.network.sendTo(new PacketAvailableBiomesSet(availableBiomes), player);
+
+            if (biome == null)
+                NaturesCompass.network.sendTo(new PacketAvailableBiomesSet(availableBiomes), player);
         }
 
         finished = true;

--- a/src/main/java/com/chaosthedude/naturescompass/util/BiomeSearchWorker.java
+++ b/src/main/java/com/chaosthedude/naturescompass/util/BiomeSearchWorker.java
@@ -119,8 +119,7 @@ public class BiomeSearchWorker implements WorldWorkerManager.IWorker {
                 ((ItemNaturesCompass) stack.getItem()).setNotFound(stack, player, roundRadius(getRadius(), 500));
             }
 
-            if (biome == null)
-                NaturesCompass.network.sendTo(new PacketAvailableBiomesSet(availableBiomes), player);
+            if (biome == null) NaturesCompass.network.sendTo(new PacketAvailableBiomesSet(availableBiomes), player);
         }
 
         finished = true;

--- a/src/main/resources/assets/naturescompass/lang/en_US.lang
+++ b/src/main/resources/assets/naturescompass/lang/en_US.lang
@@ -11,6 +11,7 @@ string.naturescompass.search=Search
 string.naturescompass.selectBiome=Select Biome
 string.naturescompass.sortBy=Sort By
 string.naturescompass.teleport=Teleport
+string.naturescompass.foundOnly=Only found biomes
 
 # STRINGS - CLIMATES
 string.naturescompass.ocean=Ocean


### PR DESCRIPTION
The current algorithm that Nature's Compass uses to search for biomes assembles a list of biomes found within its configured radius, which it uses to filter the list of biomes to search for. However, the worker that does this exits early if it finds the biome it was looking for, truncating the list to only biomes found prior to that one. It doesn't make sense to do this in general, since RWG means viable biomes could be outside of the 10k block radius, so I've cut out the filtering code entirely to just display all configured biomes in the search list unconditionally.